### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     },
     author='Gabriel Falcao',
     author_email='gabriel@nacaolivre.org',
-    url='http://repocket.readthedocs.org',
+    url='https://repocket.readthedocs.io',
     packages=find_packages(exclude=['*tests*']),
     install_requires=requirements,
     zip_safe=False,


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
